### PR TITLE
Update JsonEditorPluginsAsset.php

### DIFF
--- a/src/JsonEditorPluginsAsset.php
+++ b/src/JsonEditorPluginsAsset.php
@@ -25,6 +25,7 @@ class JsonEditorPluginsAsset extends AssetBundle
     ];
 
     public $depends = [
+        JsonEditorAsset::class,
         SelectizeAsset::class,
         CKEditorAsset::class,
         JqueryAsset::class


### PR DESCRIPTION
JsonEditorPluginsAsset was made optional a while ago and should be registered manually in order to use the CKEditor or Filefly plugin. However it needs implicitely the JsonEditorAsset.