### PR TITLE
JsonEditorWidget: add registerPluginAsset option

### DIFF
--- a/src/JsonEditorWidget.php
+++ b/src/JsonEditorWidget.php
@@ -66,6 +66,13 @@ class JsonEditorWidget extends BaseWidget
     public $language = null;
 
     /**
+     * if true JsonEditorPluginsAsset will be registered
+     *
+     * @var bool
+     */
+    public $registerPluginAsset = false;
+
+    /**
      * If true, a hidden input will be rendered to contain the results
      * @var boolean
      */
@@ -110,6 +117,9 @@ class JsonEditorWidget extends BaseWidget
         }
 
         parent::init();
+        if ($this->registerPluginAsset) {
+            JsonEditorPluginsAsset::register($this->getView());
+        }
         JsonEditorAsset::register($this->getView());
     }
 


### PR DESCRIPTION
This PR adds a new option `JsonEditorWidget::registerPluginAsset`

If set the JsonEditorPluginsAsset will be registered while init.

Until now, you always have to register the plugin asset manually "elsewhere" when plugins are needed.

With code generators like [giiant](https://github.com/schmunk42/yii2-giiant) this is error-prone and not very practical.