### PR TITLE
Resolve the issue where plugins fail to initialize when they are not …

### DIFF
--- a/src/assets/editors/ckeditor.js
+++ b/src/assets/editors/ckeditor.js
@@ -107,6 +107,9 @@ class CKEditorEditor extends StringEditor {
 
   postBuild () {
     super.postBuild();
+    if (this.container) {
+      this.initCKEditor()
+    }
     this.theme.afterInputReady(this.input);
   }
 

--- a/src/assets/editors/filefly.js
+++ b/src/assets/editors/filefly.js
@@ -99,6 +99,7 @@ class FileflyEditor extends StringEditor {
 
   postBuild () {
     super.postBuild();
+    this.initSelectize();
     this.theme.afterInputReady(this.input);
   }
 


### PR DESCRIPTION
…the primary selection within either the "oneOf" or "anyOf" options.

example:


```json
{
    "title": "An object",
    "type": "object",
    "properties": {
        "filefly": {
            "type": "string",
            "anyOf": [
                {
                    "format": "filefly"
                },
                {
                    "format": "filefly"
                }
            ]
        },
        "ckeditor": {
            "type": "string",
            "anyOf": [
                {
                    "format": "html"
                },
                {
                    "format": "html"
                }
            ]
        }
    }
}
```