### PR TITLE
get properly encoded string-values after Yii::t() calls

### DIFF
--- a/src/JsonEditorWidget.php
+++ b/src/JsonEditorWidget.php
@@ -209,66 +209,81 @@ class JsonEditorWidget extends BaseWidget
     }
 
     /**
+     * for the translated editor options, we create a php array and encode it after(!) the Yii::t() calls to get properly encoded string-values
+     *
+     * @return string
+     */
+    protected function getTranslatedEditorOptsJson()
+    {
+
+        $labels = [
+            'button_add_row_title' =>  \Yii::t('json-editor', 'Add {{0}}', [], $this->language),
+            'button_collapse' =>  \Yii::t('json-editor', 'Collapse', [], $this->language),
+            'button_copy_row_title_short' =>  \Yii::t('json-editor', 'Copy', [], $this->language),
+            'button_delete_all' =>  \Yii::t('json-editor', 'All', [], $this->language),
+            'button_delete_all_title' =>  \Yii::t('json-editor', 'Delete All', [], $this->language),
+            'button_delete_last' =>  \Yii::t('json-editor', 'Last {{0}}', [], $this->language),
+            'button_delete_last_title' =>  \Yii::t('json-editor', 'Delete Last {{0}}', [], $this->language),
+            'button_delete_node_warning' =>  \Yii::t('json-editor', 'Are you sure you want to remove this node?', [], $this->language),
+            'button_delete_row_title' =>  \Yii::t('json-editor', 'Delete {{0}}', [], $this->language),
+            'button_delete_row_title_short' =>  \Yii::t('json-editor', 'Delete', [], $this->language),
+            'button_expand' =>  \Yii::t('json-editor', 'Expand', [], $this->language),
+            'button_move_down_title' =>  \Yii::t('json-editor', 'Move down', [], $this->language),
+            'button_move_up_title' =>  \Yii::t('json-editor', 'Move up', [], $this->language),
+            'button_object_properties' =>  \Yii::t('json-editor', 'Object Properties', [], $this->language),
+            'choices_placeholder_text' =>  \Yii::t('json-editor', 'Start typing to add value', [], $this->language),
+            'default_array_item_title' =>  \Yii::t('json-editor', 'item', [], $this->language),
+            'error_additionalItems' =>  \Yii::t('json-editor', 'No additional items allowed in this array', [], $this->language),
+            'error_additional_properties' =>  \Yii::t('json-editor', 'No additional properties allowed, but property {{0}} is set', [], $this->language),
+            'error_anyOf' =>  \Yii::t('json-editor', 'Value must validate against at least one of the provided schemas', [], $this->language),
+            'error_date' =>  \Yii::t('json-editor', 'Date must be in the format {{0}}', [], $this->language),
+            'error_datetime_local' =>  \Yii::t('json-editor', 'Datetime must be in the format {{0}}', [], $this->language),
+            'error_dependency' =>  \Yii::t('json-editor', 'Must have property {{0}}', [], $this->language),
+            'error_disallow' =>  \Yii::t('json-editor', 'Value must not be of type {{0}}', [], $this->language),
+            'error_disallow_union' =>  \Yii::t('json-editor', 'Value must not be one of the provided disallowed types', [], $this->language),
+            'error_enum' =>  \Yii::t('json-editor', 'Value must be one of the enumerated values', [], $this->language),
+            'error_hostname' =>  \Yii::t('json-editor', 'The hostname has the wrong format', [], $this->language),
+            'error_invalid_epoch' =>  \Yii::t('json-editor', 'Date must be greater than 1 January 1970', [], $this->language),
+            'error_ipv4' =>  \Yii::t('json-editor', 'Value must be a valid IPv4 address in the form of 4 numbers between 0 and 255, separated by dots', [], $this->language),
+            'error_ipv6' =>  \Yii::t('json-editor', 'Value must be a valid IPv6 address', [], $this->language),
+            'error_maxItems' =>  \Yii::t('json-editor', 'Value must have at most {{0}} items', [], $this->language),
+            'error_maxLength' =>  \Yii::t('json-editor', 'Value must be at most {{0}} characters long', [], $this->language),
+            'error_maxProperties' =>  \Yii::t('json-editor', 'Object must have at most {{0}} properties', [], $this->language),
+            'error_maximum_excl' =>  \Yii::t('json-editor', 'Value must be less than {{0}}', [], $this->language),
+            'error_maximum_incl' =>  \Yii::t('json-editor', 'Value must be at most {{0}}', [], $this->language),
+            'error_minItems' =>  \Yii::t('json-editor', 'Value must have at least {{0}} items', [], $this->language),
+            'error_minLength' =>  \Yii::t('json-editor', 'Value must be at least {{0}} characters long', [], $this->language),
+            'error_minProperties' =>  \Yii::t('json-editor', 'Object must have at least {{0}} properties', [], $this->language),
+            'error_minimum_excl' =>  \Yii::t('json-editor', 'Value must be greater than {{0}}', [], $this->language),
+            'error_minimum_incl' =>  \Yii::t('json-editor', 'Value must be at least {{0}}', [], $this->language),
+            'error_multipleOf' =>  \Yii::t('json-editor', 'Value must be a multiple of {{0}}', [], $this->language),
+            'error_not' =>  \Yii::t('json-editor', 'Value must not validate against the provided schema', [], $this->language),
+            'error_notempty' =>  \Yii::t('json-editor', 'Value required', [], $this->language),
+            'error_notset' =>  \Yii::t('json-editor', 'Property must be set', [], $this->language),
+            'error_oneOf' =>  \Yii::t('json-editor', 'Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.', [], $this->language),
+            'error_pattern' =>  \Yii::t('json-editor', 'Value must match the pattern {{0}}', [], $this->language),
+            'error_required' =>  \Yii::t('json-editor', 'Object is missing the required property \"{{0}}\"', [], $this->language),
+            'error_time' =>  \Yii::t('json-editor', 'Time must be in the format {{0}}', [], $this->language),
+            'error_type' =>  \Yii::t('json-editor', 'Value must be of type {{0}}', [], $this->language),
+            'error_type_union' =>  \Yii::t('json-editor', 'Value must be one of the provided types', [], $this->language),
+            'error_uniqueItems' =>  \Yii::t('json-editor', 'Array must have unique items', [], $this->language),
+            'flatpickr_clear_button' =>  \Yii::t('json-editor', 'Clear', [], $this->language),
+            'flatpickr_toggle_button' =>  \Yii::t('json-editor', 'Toggle', [], $this->language),
+        ];
+
+        return Json::encode($labels);
+
+    }
+
+    /**
      * Register additional languages via app language
      */
     public function registerAdditionalLanguages()
     {
+
         $view = $this->getView();
         $view->registerJs("
-JSONEditor.defaults.languages['" . $this->language . "'] = {
-    button_add_row_title: '" . \Yii::t('json-editor', 'Add {{0}}', [], $this->language) . "',
-    button_collapse: '" . \Yii::t('json-editor', 'Collapse', [], $this->language) . "',
-    button_copy_row_title_short: '" . \Yii::t('json-editor', 'Copy', [], $this->language) . "',
-    button_delete_all: '" . \Yii::t('json-editor', 'All', [], $this->language) . "',
-    button_delete_all_title: '" . \Yii::t('json-editor', 'Delete All', [], $this->language) . "',
-    button_delete_last: '" . \Yii::t('json-editor', 'Last {{0}}', [], $this->language) . "',
-    button_delete_last_title: '" . \Yii::t('json-editor', 'Delete Last {{0}}', [], $this->language) . "',
-    button_delete_node_warning: '" . \Yii::t('json-editor', 'Are you sure you want to remove this node?', [], $this->language) . "',
-    button_delete_row_title: '" . \Yii::t('json-editor', 'Delete {{0}}', [], $this->language) . "',
-    button_delete_row_title_short: '" . \Yii::t('json-editor', 'Delete', [], $this->language) . "',
-    button_expand: '" . \Yii::t('json-editor', 'Expand', [], $this->language) . "',
-    button_move_down_title: '" . \Yii::t('json-editor', 'Move down', [], $this->language) . "',
-    button_move_up_title: '" . \Yii::t('json-editor', 'Move up', [], $this->language) . "',
-    button_object_properties: '" . \Yii::t('json-editor', 'Object Properties', [], $this->language) . "',
-    choices_placeholder_text: '" . \Yii::t('json-editor', 'Start typing to add value', [], $this->language) . "',
-    default_array_item_title: '" . \Yii::t('json-editor', 'item', [], $this->language) . "',
-    error_additionalItems: '" . \Yii::t('json-editor', 'No additional items allowed in this array', [], $this->language) . "',
-    error_additional_properties: '" . \Yii::t('json-editor', 'No additional properties allowed, but property {{0}} is set', [], $this->language) . "',
-    error_anyOf: '" . \Yii::t('json-editor', 'Value must validate against at least one of the provided schemas', [], $this->language) . "',
-    error_date: '" . \Yii::t('json-editor', 'Date must be in the format {{0}}', [], $this->language) . "',
-    error_datetime_local: '" . \Yii::t('json-editor', 'Datetime must be in the format {{0}}', [], $this->language) . "',
-    error_dependency: '" . \Yii::t('json-editor', 'Must have property {{0}}', [], $this->language) . "',
-    error_disallow: '" . \Yii::t('json-editor', 'Value must not be of type {{0}}', [], $this->language) . "',
-    error_disallow_union: '" . \Yii::t('json-editor', 'Value must not be one of the provided disallowed types', [], $this->language) . "',
-    error_enum: '" . \Yii::t('json-editor', 'Value must be one of the enumerated values', [], $this->language) . "',
-    error_hostname: '" . \Yii::t('json-editor', 'The hostname has the wrong format', [], $this->language) . "',
-    error_invalid_epoch: '" . \Yii::t('json-editor', 'Date must be greater than 1 January 1970', [], $this->language) . "',
-    error_ipv4: '" . \Yii::t('json-editor', 'Value must be a valid IPv4 address in the form of 4 numbers between 0 and 255, separated by dots', [], $this->language) . "',
-    error_ipv6: '" . \Yii::t('json-editor', 'Value must be a valid IPv6 address', [], $this->language) . "',
-    error_maxItems: '" . \Yii::t('json-editor', 'Value must have at most {{0}} items', [], $this->language) . "',
-    error_maxLength: '" . \Yii::t('json-editor', 'Value must be at most {{0}} characters long', [], $this->language) . "',
-    error_maxProperties: '" . \Yii::t('json-editor', 'Object must have at most {{0}} properties', [], $this->language) . "',
-    error_maximum_excl: '" . \Yii::t('json-editor', 'Value must be less than {{0}}', [], $this->language) . "',
-    error_maximum_incl: '" . \Yii::t('json-editor', 'Value must be at most {{0}}', [], $this->language) . "',
-    error_minItems: '" . \Yii::t('json-editor', 'Value must have at least {{0}} items', [], $this->language) . "',
-    error_minLength: '" . \Yii::t('json-editor', 'Value must be at least {{0}} characters long', [], $this->language) . "',
-    error_minProperties: '" . \Yii::t('json-editor', 'Object must have at least {{0}} properties', [], $this->language) . "',
-    error_minimum_excl: '" . \Yii::t('json-editor', 'Value must be greater than {{0}}', [], $this->language) . "',
-    error_minimum_incl: '" . \Yii::t('json-editor', 'Value must be at least {{0}}', [], $this->language) . "',
-    error_multipleOf: '" . \Yii::t('json-editor', 'Value must be a multiple of {{0}}', [], $this->language) . "',
-    error_not: '" . \Yii::t('json-editor', 'Value must not validate against the provided schema', [], $this->language) . "',
-    error_notempty: '" . \Yii::t('json-editor', 'Value required', [], $this->language) . "',
-    error_notset: '" . \Yii::t('json-editor', 'Property must be set', [], $this->language) . "',
-    error_oneOf: '" . \Yii::t('json-editor', 'Value must validate against exactly one of the provided schemas. It currently validates against {{0}} of the schemas.', [], $this->language) . "',
-    error_pattern: '" . \Yii::t('json-editor', 'Value must match the pattern {{0}}', [], $this->language) . "',
-    error_required: '" . \Yii::t('json-editor', 'Object is missing the required property \"{{0}}\"', [], $this->language) . "',
-    error_time: '" . \Yii::t('json-editor', 'Time must be in the format {{0}}', [], $this->language) . "',
-    error_type: '" . \Yii::t('json-editor', 'Value must be of type {{0}}', [], $this->language) . "',
-    error_type_union: '" . \Yii::t('json-editor', 'Value must be one of the provided types', [], $this->language) . "',
-    error_uniqueItems: '" . \Yii::t('json-editor', 'Array must have unique items', [], $this->language) . "',
-    flatpickr_clear_button: '" . \Yii::t('json-editor', 'Clear', [], $this->language) . "',
-    flatpickr_toggle_button: '" . \Yii::t('json-editor', 'Toggle', [], $this->language) . "'
-};
+JSONEditor.defaults.languages['" . $this->language . "'] = " . $this->getTranslatedEditorOptsJson() . ";
 JSONEditor.defaults.language = '" . $this->language . "';",
             \yii\web\View::POS_READY,
             'json-editor'


### PR DESCRIPTION
Currently the Editor options are added as translations without escaping in [`JsonEditorWidget::registerAdditionalLanguages()`](https://github.com/dmstr/yii2-json-editor/blob/5ef0868adc42acce3dd4d1ba6f96ad31dcf951fe/src/JsonEditorWidget.php#L214).
```
$view->registerJs("
JSONEditor.defaults.languages['" . $this->language . "'] = {
    button_add_row_title: '" . \Yii::t('json-editor', 'Add {{0}}', [], $this->language) . "',
    button_collapse: '" . \Yii::t('json-editor', 'Collapse', [], $this->language) . "',
    button_copy_row_title_short: '" . \Yii::t('json-editor', 'Copy', [], $this->language) . "',
    button_delete_all: '" . \Yii::t('json-editor', 'All', [], $this->language) . "',
    button_delete_all_title: '" . \Yii::t('json-editor', 'Delete All', [], $this->language) . "',
    button_delete_last: '" . \Yii::t('json-editor', 'Last {{0}}', [], $this->language) . "',
    button_delete_last_title: '" . \Yii::t('json-editor', 'Delete Last {{0}}', [], $this->language) . "',
    #.......
```

This leads to broken json if one add a `'` within the translated string.

`Delete Last {{0}}` - `Cancella l'ultimo {{0}}`

This PR add a new method `getTranslatedEditorOptsJson()` where a PHP array is build with the translated options which then will be encoded as Json before inserted in the dynamic JS String.